### PR TITLE
Adds the autocomplete field to Items

### DIFF
--- a/alfred.go
+++ b/alfred.go
@@ -17,6 +17,7 @@ type AlfredResponseItem struct {
 	Uid string `xml:"uid,attr"`
 	Title string `xml:"title"`
 	Subtitle string `xml:"subtitle"`
+	Autocomplete string `xml:"autocomplete"`
 	Icon string `xml:"icon"`
 
 	XMLName struct{} `xml:"item"`


### PR DESCRIPTION
See: http://support.alfredapp.com/workflows:config:inputs-script-filter#toc10

“An optional but recommended string you can provide which is populated into Alfred's search field if the user auto-complete's the selected result (⇥ by default).”
